### PR TITLE
Allow configuration of unknown portal IP addresses

### DIFF
--- a/targetcli/ui_target.py
+++ b/targetcli/ui_target.py
@@ -930,8 +930,8 @@ class UIPortals(UINode):
                                          + "create the Network Portal.")
                     return
         elif ip_address not in utils.list_eth_ips() and not listen_all:
-            self.shell.log.error("IP address does not exist: %s" % ip_address)
-            return
+            self.shell.log.warning("IP address %s does not exist on this host."
+                                   % ip_address)
 
         try:
             ip_port = int(ip_port)


### PR DESCRIPTION
Targetcli currently blocks the configuration of portal addresses that
don't match local IP addresses, even for disabled TPGs.

This commit changes the error to a warning, so that the newly added
tpg_enabled_sendtargets kernel functionality can be used.

Signed-off-by: David Disseldorp ddiss@suse.de
